### PR TITLE
Create c2jn-smart-city-compound.json-ld

### DIFF
--- a/jsonld-contexts/c2jn-smart-city-compound.json-ld
+++ b/jsonld-contexts/c2jn-smart-city-compound.json-ld
@@ -1,0 +1,9 @@
+{
+  "@context": [
+    "https://raw.githubusercontent.com/easy-global-market/ngsild-api-data-models/master/weather/jsonld-contexts/weather.jsonld",
+    "https://raw.githubusercontent.com/smart-data-models/dataModel.Environment/master/context.jsonld",
+    "https://raw.githubusercontent.com/smart-data-models/dataModel.Weather/master/context.jsonld",
+    "https://raw.githubusercontent.com/smart-data-models/dataModel.Transportation/master/context.jsonld",
+    "https://raw.githubusercontent.com/easy-global-market/c2jn-data-models/main/jsonld-contexts/transportation-extensions.jsonld"
+  ]
+}


### PR DESCRIPTION
C2JN compoound without DCAT, Authorization and Core context.

To be used by Twin picks which already holds those contexts